### PR TITLE
Update base.njk with right govuk-frontend-3.11.0 CSS

### DIFF
--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -8,7 +8,7 @@
     {# For Internet Explorer 8, you need to compile specific stylesheet #}
     {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
     <!--[if IE 8]>
-      <link href="{{assetPath}}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-ie8-4.6.0.min.css" rel="stylesheet" />
+      <link href="{{assetPath}}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-ie8-3.11.0.min.css" rel="stylesheet" />
     <![endif]-->
     {% block download %}{% endblock %}
 {% endblock %}
@@ -21,7 +21,7 @@
 
 {% block bodyEnd %}
     {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-    <script src="{{assetPath}}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js"></script>
+    <script src="{{assetPath}}/javascripts/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.js"></script>
     <script>
         window
             .GOVUKFrontend

--- a/src/views/base.njk
+++ b/src/views/base.njk
@@ -2,7 +2,7 @@
 
 {% block head %}
     <!--[if !IE 8]><!-->
-    <link href="{{assetPath}}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.css" rel="stylesheet"/>
+    <link href="{{assetPath}}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css" rel="stylesheet"/>
     <!--<![endif]-->
 
     {# For Internet Explorer 8, you need to compile specific stylesheet #}


### PR DESCRIPTION
Resolving 404 error on icons load by updating the govuk-frontend-3.11.0 CSS as the same css is used in other web apps which doesn't have 404 load issue

Jira Ticket : https://companieshouse.atlassian.net/browse/CC-1145 

This was noticed as part of Node V20 upgrade so getting it fixed as part of it 